### PR TITLE
fix(icon): fixing main page icons tag on menu cards.

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -16,8 +16,8 @@ read the "[About](about)" page.
     {{< card link="docs" title="Docs" icon="book-open" >}}
     {{< card link="about" title="About" icon="user" >}}
     {{< card link="https://mikaelgois.github.io" title="Portfolio" icon="code" >}}
-    {{< card link="https://www.github.io/mikaelgois" title="GitHub" icon"github" >}}
-    {{< card link="https://www.msglabs.site/" title="Digital Lab" icon"beaker" >}}
+    {{< card link="https://www.github.io/mikaelgois" title="GitHub" icon="github" >}}
+    {{< card link="https://www.msglabs.site/" title="Digital Lab" icon="beaker" >}}
 {{< /cards >}}
 
 <!-- ## Documentation

--- a/content/_index.md
+++ b/content/_index.md
@@ -15,8 +15,8 @@ leia a página "[Sobre](about)".
     {{< card link="docs" title="Arquivos" icon="book-open" >}}
     {{< card link="about" title="Sobre" icon="user" >}}
     {{< card link="https://mikaelgois.github.io" title="Portfólio" icon="code" >}}
-    {{< card link="https://www.github.io/mikaelgois" title="GitHub" icon"github" >}}
-    {{< card link="https://www.msglabs.site/" title="Lab digital" icon"beaker" >}}
+    {{< card link="https://www.github.io/mikaelgois" title="GitHub" icon="github" >}}
+    {{< card link="https://www.msglabs.site/" title="Lab digital" icon="beaker" >}}
 {{< /cards >}}
 
 <!-- ## Documentation


### PR DESCRIPTION
[This was generated by Copilot]

This pull request fixes typos in the `icon` attributes of cards in two files, ensuring proper formatting and consistency.

Typos fixed in card attributes:

* [`content/_index.en.md`](diffhunk://#diff-1e6d4067d1d59d91bd76f5f3753b48f245483e3edac55eea840c358c32bb53bcL19-R20): Corrected the `icon` attributes for "GitHub" and "Digital Lab" cards to use proper syntax (`icon="github"` and `icon="beaker"`).
* [`content/_index.md`](diffhunk://#diff-200abda264c3530e9cdb5d895e25d50bc3ed567079b39fe2ee3c1d1b5d661e09L18-R19): Fixed the `icon` attributes for "GitHub" and "Lab digital" cards to match the correct syntax (`icon="github"` and `icon="beaker"`).