### PR TITLE
Test/directory tree

### DIFF
--- a/content/about.en.md
+++ b/content/about.en.md
@@ -3,6 +3,7 @@ title: About
 type: about
 weight: 2
 ---
+
 <style>body {text-align: justify}</style>
 Don't worry!
 This is a WIP, I'm still thinking about how I'm going to do this.
@@ -44,5 +45,5 @@ in addition to being a well-designed tool and using Markdown and LaTeX to write 
 won me over with the possibility of implementing the project with GitHub Pages. 
 In addition, the devs provide a template that makes implementing the project much easier.
 
-> "The only true wisdom is in knowing you know nothing."
+> "The only true wisdom is in knowing you know nothing."<br>
 > — <cite>Socrates</cite>

--- a/content/about.md
+++ b/content/about.md
@@ -1,5 +1,5 @@
 ---
-title: Sobre 
+title: Sobre
 type: about
 weight: 2
 ---

--- a/content/articles/2025/07/_index.md
+++ b/content/articles/2025/07/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Julho
 type: docs
+weight: 1
 prev: articles/2025/_index
 next: articles/2025/07/leaf
 sidebar:

--- a/content/articles/2025/07/testone.en.md
+++ b/content/articles/2025/07/testone.en.md
@@ -1,0 +1,6 @@
+---
+title: Teste 1
+type: blog
+---
+
+This is the first test to see how directory tree works

--- a/content/articles/2025/07/testone.md
+++ b/content/articles/2025/07/testone.md
@@ -1,0 +1,6 @@
+---
+title: Teste 1
+---
+
+Primeiro teste para saber o comportamento da arvore de diretorios.
+Esta página não tem peso.

--- a/content/articles/2025/07/testtwo.en.md
+++ b/content/articles/2025/07/testtwo.en.md
@@ -1,0 +1,6 @@
+---
+title: Test 2
+type: blog
+---
+
+This is the first test to see how directory tree works

--- a/content/articles/2025/07/testtwo.md
+++ b/content/articles/2025/07/testtwo.md
@@ -1,0 +1,7 @@
+---
+name: Teste 2
+weight: 1
+---
+
+Segundo teste para saber o comportamento da arvore de diretorios.
+Esta página tem peso 1

--- a/content/articles/_index.md
+++ b/content/articles/_index.md
@@ -1,5 +1,7 @@
 ---
 title: Artigos
+type: default
+weight: 1
 sidebar:
     exclude: true
 next: articles/2025/07/_index.md
@@ -18,3 +20,5 @@ func main() {
     fmt.Println("Hello, World!")
 }
 ```
+
+[página de teste](articles/2025/07/leaf)


### PR DESCRIPTION
This pull request introduces updates to content organization, styling, and test pages across the project. The changes include the addition of new test pages, updates to metadata for better directory structure handling, and minor styling adjustments.

### Content and Metadata Updates:

* [`content/articles/_index.md`](diffhunk://#diff-2a969b9ea3d7f7313348abdac3f7cd07cdbd6d72d13d0ca6957a9f41f9370352R3-R4): Added `type: default` and `weight: 1` to improve sorting and categorization of articles. Also added a test page link for navigation. [[1]](diffhunk://#diff-2a969b9ea3d7f7313348abdac3f7cd07cdbd6d72d13d0ca6957a9f41f9370352R3-R4) [[2]](diffhunk://#diff-2a969b9ea3d7f7313348abdac3f7cd07cdbd6d72d13d0ca6957a9f41f9370352R23-R24)
* [`content/articles/2025/07/_index.md`](diffhunk://#diff-f4fefc470b75eafbbffa13bb015ca1092eafdf551b4071907a41e7fd5aae5413R4): Added `weight: 1` to ensure proper ordering in the directory tree.

### Test Pages:

* [`content/articles/2025/07/testone.en.md`](diffhunk://#diff-d332c0a2861ffa2221447d33217ec46e37193aeca07f56613c8aae7430a454adR1-R6): Added a new test page in English to verify directory tree behavior.
* [`content/articles/2025/07/testone.md`](diffhunk://#diff-a2d957faef24895ea5bf52298011cbb89ebc91c4aa04a39fbb6e4418673f63adR1-R6): Added a corresponding test page in Portuguese without weight metadata.
* [`content/articles/2025/07/testtwo.en.md`](diffhunk://#diff-449128c5350330cc822d755d949e61de0cf9d493e025d7e6ba99161b75ad8094R1-R6): Added another test page in English with similar content for directory tree testing.
* [`content/articles/2025/07/testtwo.md`](diffhunk://#diff-29ce7772e63508ff28de383b402849c33befd1e2ad0bd843f8d2edbf2aacde63R1-R7): Added a Portuguese version of the second test page with `weight: 1` for ordering.

### Styling Enhancements:

* [`content/about.en.md`](diffhunk://#diff-69282c5a45fa7372b3ecbf022bd50e8747e8762ec8bdc993f6858dfc66befb73R6): Added inline CSS to justify text alignment and improved formatting for a blockquote by adding a line break after the quote. [[1]](diffhunk://#diff-69282c5a45fa7372b3ecbf022bd50e8747e8762ec8bdc993f6858dfc66befb73R6) [[2]](diffhunk://#diff-69282c5a45fa7372b3ecbf022bd50e8747e8762ec8bdc993f6858dfc66befb73L47-R48)