### PR TITLE
Test: directory tree teste 2

### DIFF
--- a/content/articles/2025/07/testone.en.md
+++ b/content/articles/2025/07/testone.en.md
@@ -3,4 +3,5 @@ title: Teste 1
 type: blog
 ---
 
+## test 1
 This is the first test to see how directory tree works

--- a/content/articles/2025/07/testone.md
+++ b/content/articles/2025/07/testone.md
@@ -2,5 +2,6 @@
 title: Teste 1
 ---
 
+## teste 1
 Primeiro teste para saber o comportamento da arvore de diretorios.
 Esta página não tem peso.

--- a/content/articles/2025/07/testtwo.en.md
+++ b/content/articles/2025/07/testtwo.en.md
@@ -1,6 +1,8 @@
 ---
 title: Test 2
 type: blog
+weight: 1
 ---
 
+## test 2
 This is the first test to see how directory tree works

--- a/content/articles/2025/07/testtwo.md
+++ b/content/articles/2025/07/testtwo.md
@@ -3,5 +3,6 @@ name: Teste 2
 weight: 1
 ---
 
+## teste 2
 Segundo teste para saber o comportamento da arvore de diretorios.
 Esta página tem peso 1

--- a/content/articles/_index.md
+++ b/content/articles/_index.md
@@ -1,9 +1,9 @@
 ---
 title: Artigos
-type: default
-weight: 1
+cascade:
+    type: default
 sidebar:
-    exclude: true
+    exclude: false
 next: articles/2025/07/_index.md
 ---
 


### PR DESCRIPTION
This pull request introduces new test articles in English and Portuguese to evaluate directory tree behavior, assigns weights to some articles for ordering, and modifies the `_index.md` file to adjust cascading properties and sidebar behavior.

### New test articles:

* [`content/articles/2025/07/testone.en.md`](diffhunk://#diff-d332c0a2861ffa2221447d33217ec46e37193aeca07f56613c8aae7430a454adR6): Added a new English test article titled "Test 1" with a section header and description.
* [`content/articles/2025/07/testone.md`](diffhunk://#diff-a2d957faef24895ea5bf52298011cbb89ebc91c4aa04a39fbb6e4418673f63adR5): Added a new Portuguese test article titled "Teste 1" with a section header and description.
* [`content/articles/2025/07/testtwo.en.md`](diffhunk://#diff-449128c5350330cc822d755d949e61de0cf9d493e025d7e6ba99161b75ad8094R4-R7): Added a new English test article titled "Test 2" with a section header, description, and a weight of 1 for ordering.
* [`content/articles/2025/07/testtwo.md`](diffhunk://#diff-29ce7772e63508ff28de383b402849c33befd1e2ad0bd843f8d2edbf2aacde63R6): Added a new Portuguese test article titled "Teste 2" with a section header, description, and a weight of 1 for ordering.

### Adjustments to `_index.md`:

* [`content/articles/_index.md`](diffhunk://#diff-2a969b9ea3d7f7313348abdac3f7cd07cdbd6d72d13d0ca6957a9f41f9370352R3-R6): Updated cascading properties to set `type` to `default`, adjusted `weight` by removing it, and changed the sidebar's `exclude` property to `false`.