### PR TITLE
Fix(navbar): fixing article page link and adding google analytics.

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -20,7 +20,7 @@ menu:
   main:
     - identifier: articles
       name: Arquivos
-      pageRef: /articles/_index
+      pageRef: /articles
       weight: 1
     - identifier: about
       name: Sobre
@@ -77,3 +77,7 @@ params:
   # Display the last modification date
   displayUpdatedDate: true
   dateFormat: "2 Jan 2006"
+
+services:
+  googleAnalytics:
+    ID: G-HDM7GF199V


### PR DESCRIPTION
[This was generated by Copilot]

This pull request makes updates to the `hugo.yaml` configuration file, including a fix to the `pageRef` for the "articles" menu item and the addition of Google Analytics configuration under `params`.

### Menu configuration updates:
* Updated the `pageRef` for the "articles" menu item from `/articles/_index` to `/articles` to correct the reference.

### Analytics configuration:
* Added a new `services` section under `params` to configure Google Analytics with the ID `G-HDM7GF199V`.