### PR TITLE
Feat(articles): Updating the 'Hadoop Cluster' file.

### DIFF
--- a/content/articles/2025/07/1-hadoop-cluster.md
+++ b/content/articles/2025/07/1-hadoop-cluster.md
@@ -6,11 +6,9 @@ weight: 2
 
 <style>body {text-align: justify}</style>
 
-Este artigo foi originalmente criado em 2023 como parte do projeto de avaliação da 2ª unidade da disciplina de Arquitetura de Computadores no curso de bacharelado em Ciência da Computação do Instituto Federal de Sergipe, curso do qual sou discente.
+Este artigo foi originalmente criado em 2023 como parte do projeto de avaliação da 2ª unidade da disciplina de Arquitetura de Computadores no curso de bacharelado em Ciência da Computação do Instituto Federal de Sergipe, curso do qual sou discente.  
 
-
-Mantinha o documento apenas no meu Google Drive, porém achei que seria uma boa ideia escrever aqui e revisar parte do conteúdo.
-
+Mantinha o documento apenas no meu Google Drive, porém achei que seria uma boa ideia escrever aqui e revisar parte do conteúdo.  
 
 Temos o seguinte cenário: 3 SBCs *Raspberry Pi*, onde uma será a "*main*", ou seja, 
 vai controlar todo o *cluster* e duas atuarão como "*nodes*" que serão responsáveis pelo processamento propriamente dito. 


### PR DESCRIPTION
[This was generated by Copilot]

This pull request refines the article on setting up a Hadoop cluster by improving formatting, enhancing clarity, and ensuring consistent terminology. The changes focus on adding emphasis to technical terms, correcting minor grammatical issues, and improving the readability of instructions.

### Improvements to formatting and terminology:

* Added emphasis (italics or bold) to technical terms like `main`, `nodes`, `cluster`, `environment`, and `interface` to improve readability and highlight key concepts (`content/articles/2025/07/1-hadoop-cluster.md`, [[1]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L9-R36) [[2]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L48-R57) [[3]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L75-R73) [[4]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L95-R106) [[5]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L198-R211) [[6]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L297-R301).
* Standardized terminology throughout the article, such as consistently using "*main*" instead of "master/main" and "*nodes*" instead of "nodes" (`content/articles/2025/07/1-hadoop-cluster.md`, [[1]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L176-R174) [[2]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L256-R254) [[3]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L353-R358).

### Enhancements to clarity:

* Improved sentence structure and grammar in various sections to make the instructions easier to follow (e.g., rephrased explanations for updating packages, configuring static IPs, and applying network changes) (`content/articles/2025/07/1-hadoop-cluster.md`, [[1]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L9-R36) [[2]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L198-R211) [[3]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L269-R267).
* Clarified the purpose and functionality of certain parameters in Hadoop configuration files, such as `fs.defaultFS`, `dfs.replication`, and `mapreduce.framework.name` (`content/articles/2025/07/1-hadoop-cluster.md`, [[1]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L384-R386) [[2]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L419-R421) [[3]](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152L477-R486).

### Additional configuration details:

* Added a new property `yarn.log-aggregation.retain-seconds` in the YARN configuration file to specify the retention period for aggregated logs (`content/articles/2025/07/1-hadoop-cluster.md`, [content/articles/2025/07/1-hadoop-cluster.mdR513-R516](diffhunk://#diff-f36a69dab9f08f9ab60b9fdab284d7ab1e4b84be925483e233cef58d14bf7152R513-R516)).

These changes collectively improve the usability of the article for readers setting up a Hadoop cluster.