### PR TITLE
Fix(articles): Fixing dns and proxy paths

### DIFF
--- a/content/articles/2025/08/2-dns-and-proxy-server-rockylinux.md
+++ b/content/articles/2025/08/2-dns-and-proxy-server-rockylinux.md
@@ -283,7 +283,7 @@ controls {
         keys { rndc-key; };
 };
 
-include "/etc/main.local.zones"; // Zona de pesquisa direta e reversa que será criada
+include "/etc/named.main.local.zones"; // Zona de pesquisa direta e reversa que será criada
 include "/etc/named.rfc1912.zones"; // Zonas de pesquisa direta e reversa padrão
 include "/etc/named.root.key"; // Chave de autenticação para o servidor raiz
 ```
@@ -320,13 +320,13 @@ zone "." IN {
 
 As zonas de consulta direta são usadas para resolver nomes de domínio em endereços IP, já as zonas de consulta reversa são usadas para resolver endereços IP em nomes de domínio. Para configurar uma zona direta e reversa, você precisa criar um arquivo de zona e adicionar as entradas necessárias.
 ```bash
-sudo vi /etc/named/main.local.zones
+sudo vi /etc/named.main.local.zones
 ```
 
 Digite `i` para entrar no modo de inserção e faça as alterações necessárias.
 
 Dentro do arquivo, adicione as informações das zonas:
-```bash {filename="main.zones",linenos=table}
+```bash {filename="named.main.local.zones",linenos=table}
 zone "main.local" IN {
     type master;
     file "main.local.zone";
@@ -359,8 +359,8 @@ Pressione `Esc` e digite `:wq` para salvar e sair do editor.
 #### 3.3 - Conceda a propriedade e as permissões adequadas ao arquivo de declaração de zona:
 Para garantir que o BIND tenha acesso ao arquivo de zonas, você deve definir a propriedade e as permissões corretas:
 ```bash
-sudo chown root:named /etc/named/main.local.zones
-sudo chmod 644 /etc/named/main.local.zones
+sudo chown root:named /etc/named/named.main.local.zones
+sudo chmod 644 /etc/named/named.main.local.zones
 ```
 
 


### PR DESCRIPTION
[This was generated by Copilot]

This pull request updates the configuration and documentation for DNS zone files in Rocky Linux to ensure consistency in file naming and references. The main focus is on renaming the zone file from `main.local.zones` to `named.main.local.zones` and updating all related instructions and configuration includes accordingly.

**DNS zone file naming and references:**

* Updated the `include` directive in the BIND configuration to reference `named.main.local.zones` instead of `main.local.zones`.
* Changed all documentation and command references from `/etc/named/main.local.zones` to `/etc/named/named.main.local.zones`, including file creation, editing, and permission commands. [[1]](diffhunk://#diff-d1729beda3dbb5f7fd88ce4c3ed8f51d81e37b96d7d5bc56a0494c4e10f11758L323-R329) [[2]](diffhunk://#diff-d1729beda3dbb5f7fd88ce4c3ed8f51d81e37b96d7d5bc56a0494c4e10f11758L362-R363)
* Updated code block filenames and examples to use `named.main.local.zones` for clarity and consistency.