### PR TITLE
Fix(articles): Fixing routing policy

### DIFF
--- a/content/articles/2025/08/2-dns-and-proxy-server-rockylinux.md
+++ b/content/articles/2025/08/2-dns-and-proxy-server-rockylinux.md
@@ -81,12 +81,12 @@ sudo firewall-cmd --new-policy=int-to-ext --permanent
 #### 4.2 - Definindo as zonas de entrada e saída:
 Para definir a zona de entrada (`ingress`), use o comando abaixo:
 ```bash
-sudo firewall-cmd --policy=int-to-ext --set-ingress-zone=internal --permanent
+sudo firewall-cmd --policy=int-to-ext --add-ingress-zone=internal --permanent
 ```
 
 Já para definir a zona de saída (`egress`), use o comando abaixo:
 ```bash
-sudo firewall-cmd --policy=int-to-ext --set-egress-zone=external --permanent
+sudo firewall-cmd --policy=int-to-ext --add-egress-zone=external --permanent
 ```
 
 #### 4.3 - Definindo a zona padrão:
@@ -94,6 +94,15 @@ Também é importante configurar a zona internal como a zona padrão do servidor
 ```bash
 sudo firewall-cmd --set-default-zone=internal
 ```
+
+#### 4.4 - Definindo a política de roteamento padrão:
+Para definir a política de roteamento padrão, use o comando abaixo:
+```bash
+sudo firewall-cmd --policy=int-to-ext --set-target=ACCEPT --permanent
+```
+
+
+
 
 ### 5 - Aplicando mudanças no firewall
 Após realizar todas as alterações, é necessário recarregar as configurações do firewall para que as mudanças tenham efeito:


### PR DESCRIPTION
[This was generated by Copilot]

This pull request updates the firewall configuration instructions in the Rocky Linux DNS and proxy server article to correct command usage and add a missing step for setting the default routing policy.

**Corrections and improvements to firewall configuration instructions:**

* Updated the commands for setting ingress and egress zones to use `--add-ingress-zone` and `--add-egress-zone` instead of the incorrect `--set-ingress-zone` and `--set-egress-zone` options.
* Added a new section with the command to set the default routing policy target using `--set-target=ACCEPT`, clarifying the configuration steps.