### PR TITLE
fix(content): correcting the text of some articles

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -14,7 +14,7 @@ leia a página "[Sobre](about)".
 ## Explorar
 
 {{< cards >}}
-    {{< card link="articles" title="Arquivos" icon="book-open" >}}
+    {{< card link="articles" title="Artigos" icon="book-open" >}}
     {{< card link="about" title="Sobre" icon="user" >}}
     {{< card link="https://mikaelgois.github.io" title="Portfólio" icon="code" >}}
     {{< card link="https://www.github.com/mikaelgois" title="GitHub" icon="github" >}}

--- a/content/about.en.md
+++ b/content/about.en.md
@@ -44,6 +44,7 @@ in this case [Hextra](https://github.com/imfing/hextra), which,
 in addition to being a well-designed tool and using Markdown and LaTeX to write the pages (features that I consider important), 
 won me over with the possibility of implementing the project with GitHub Pages. 
 In addition, the devs provide a template that makes implementing the project much easier.
+Additionally, I used the option to add a custom DNS on GitHub, which makes the site more professional and memorable.
 
 > "The only true wisdom is in knowing you know nothing."<br>
 > — <cite>Socrates</cite>

--- a/content/about.md
+++ b/content/about.md
@@ -44,6 +44,7 @@ o que serviu como inspiração para começar as anotações, e também para a fe
 no caso o [Hextra](https://github.com/imfing/hextra) que além de ser uma ferramenta bem elaborada e usar o Markdown e LaTeX para realizar a escrita das páginas (funcionalidades que considero importantes), 
 me conquistou com a possibilidade de implementar o projeto com o GitHub Pages. 
 Além disso, os devs disponibilizaram um template que facilita muito a implementação do projeto.
+Somado a isso, utilizei a opção de adicionar um DNS personalizado no GitHub, o que torna o site mais profissional e fácil de ser lembrado.
 
 > "A verdadeira virtude só existe acompanhada da sabedoria."<br>
 > — <cite>Platão</cite>

--- a/content/articles/2025/07/1-hadoop-cluster.md
+++ b/content/articles/2025/07/1-hadoop-cluster.md
@@ -14,7 +14,7 @@ No trabalho da faculdade, tínhamos o seguinte cenário: 3 SBCs *Raspberry Pi*, 
 É possível incluir a máquina *main* como um dos *nodes*, ou seja, além de coordenar todo o *cluster*, ela também processa os dados, porém, não é essa abordagem adotada aqui, na verdade, essa revisão usará máquinas virtuais e uma configuração melhorada. No entanto, haverá uma indicação para aqueles que decidirem colocar a *main* para processar os dados juntamente com os *nodes*.
 
 > [!IMPORTANT]
-> Os valores abordados e os parâmetros usados foram utilizados conforme a necessidade do projeto e dos testes realizados, e portanto não devem ser seguidos a pé da letra.  
+> Os valores abordados e os parâmetros usados foram utilizados conforme a necessidade do projeto e dos testes realizados, e portanto não devem ser seguidos ao pé da letra.  
 > Ajuste todos os parâmetros conforme as necessidades do seu projeto e a capacidade do seu hardware.
 
 ## Atualizando os repositórios e pacotes:

--- a/content/articles/2025/08/1-zabbix-and-grafana.md
+++ b/content/articles/2025/08/1-zabbix-and-grafana.md
@@ -6,14 +6,19 @@ editURL: "https://devnotes.msglabs.site/articles/zabbix-and-grafana/"
 next: /articles/2025/07/1-hadoop-cluster
 ---
 
-## Passos opcionais:
+Esse artigo descreve como instalar e configurar o Zabbix e o Grafana para monitorar o cluster de computadores que foi configurado no artigos anterior, sendo o segundo de uma série de 4 artigos. Porem, as informações podem ser usadas para em qualquer outro cenário.
 
-Os passos a seguir são opcionais, ou seja, não são essenciais para o funcionamento do cluster. 
+No cenário do cluster, os passos a seguir são opcionais, ou seja, não são essenciais para o funcionamento dele. 
 Porém, monitoramento é algo essencial para qualquer sistema, portanto é recomendado a implementação.
 
 > [!WARNING]
-> Recomendável fazer as instalações, ou pelo menos baixar os pacotes, antes de configurar a rede (passo 6).
+> Recomendável fazer as instalações, ou pelo menos baixar os pacotes, antes de configurar a rede (passo 6) no guia "Criando um cluster de computadores com Apache Hadoop".
 > Também é recomendável usar uma máquina a parte para realizar o monitoramento, ou seja, uma máquina que não faz parte do cluster. A ideia é evitar processamento na máquina `main`.
+
+Outros artigos da série:
+* [Criando um cluster de computadores com Apache Hadoop](/articles/2025/07/1-hadoop-cluster)
+* [Realizando testes de benchmark com o Hadoop (em breve)](#)
+* [Automatizando a configuração de servidores com Ansible (em breve)](#)
 
 ### 1 - Instalação e configuração do zabbix:
 

--- a/content/articles/2025/08/1-zabbix-and-grafana.md
+++ b/content/articles/2025/08/1-zabbix-and-grafana.md
@@ -6,7 +6,7 @@ editURL: "https://devnotes.msglabs.site/articles/zabbix-and-grafana/"
 next: /articles/2025/07/1-hadoop-cluster
 ---
 
-Esse artigo descreve como instalar e configurar o Zabbix e o Grafana para monitorar o cluster de computadores que foi configurado no artigos anterior, sendo o segundo de uma série de 4 artigos. Porem, as informações podem ser usadas para em qualquer outro cenário.
+Esse artigo descreve como instalar e configurar o Zabbix e o Grafana para monitorar o cluster de computadores que foi configurado no artigo anterior, sendo o segundo de uma série de 4 artigos. Porém, as informações podem ser usadas para em qualquer outro cenário.
 
 No cenário do cluster, os passos a seguir são opcionais, ou seja, não são essenciais para o funcionamento dele. 
 Porém, monitoramento é algo essencial para qualquer sistema, portanto é recomendado a implementação.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -19,7 +19,7 @@ markup:
 menu:
   main:
     - identifier: articles
-      name: Arquivos
+      name: Artigos
       pageRef: /articles
       weight: 1
     - identifier: about


### PR DESCRIPTION
This pull request introduces several improvements to the documentation and user interface, focusing on clarity, professionalism, and consistency across both Portuguese and English versions of the site. The most significant changes include corrections to terminology, enhancements to article introductions, and updates to project descriptions.

Content and terminology updates:

* Changed the label from "Arquivos" to "Artigos" in both the homepage card (`content/_index.md`) and the main menu (`hugo.yaml`) for better clarity and consistency. [[1]](diffhunk://#diff-200abda264c3530e9cdb5d895e25d50bc3ed567079b39fe2ee3c1d1b5d661e09L17-R17) [[2]](diffhunk://#diff-5928f4025679c9eee397ca3795367f71f667ce1f25018b7f7ae7c574da1f2f08L22-R22)

Documentation enhancements:

* Improved the introduction of the Zabbix and Grafana article (`content/articles/2025/08/1-zabbix-and-grafana.md`) to clarify its context in a series and added links to related articles for easier navigation. Also updated warnings to reference the correct guide.

Project description updates:

* Added a note in both Portuguese (`content/about.md`) and English (`content/about.en.md`) about using a custom DNS with GitHub Pages to make the site more professional and memorable. [[1]](diffhunk://#diff-ee46084298e2efd451ab1a208f78b23068ba5d76488857185f5c8f98c0764353R47) [[2]](diffhunk://#diff-69282c5a45fa7372b3ecbf022bd50e8747e8762ec8bdc993f6858dfc66befb73R47)

Minor corrections:

* Fixed a typo in the Hadoop cluster article (`content/articles/2025/07/1-hadoop-cluster.md`) for improved readability.