### PR TITLE
feat(pages): adding a custom 404 page, PT and EN version

### DIFF
--- a/layouts/404.en.html
+++ b/layouts/404.en.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="pt">
+  <body style='font-family:system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"; height:100vh; text-align:center; display:flex; flex-direction:column; align-items:center; justify-content:center'>
+    <div>
+      <style>
+        body {
+          color: #000;
+          background: #fff;
+          margin: 0;
+        }
+
+        .next-error-h1 {
+           border-right: 1px solid rgba(0, 0, 0, 0.3);
+        }
+
+        @media (prefers-color-scheme: dark) {
+          body {
+            color: #fff;
+            background: #000;
+          }
+
+          .next-error-h1 {
+            border-right: 1px solid rgba(255, 255, 255, 0.3);
+          }
+        }
+        a {
+          margin-top: 2rem;
+          color: #fff;
+        }
+        a:visited {
+          color: #fff;
+          text-decoration: none;
+        }
+      </style>
+      <h1 class="next-error-h1" style='display: inline-block; margin: 0 20px 0 0; padding-right: 23px; font-size: 24px; font-weight: 500; vertical-align: top; line-height: 49px; font-feature-settings: "rlig" 1,"calt" 1,"ss01" 1,"ss06" 1 !important;'>
+        404
+      </h1>
+      <div style="display: inline-block; text-align: left">
+        <h2 style="font-size: 14px; font-weight: 400; line-height: 49px; margin: 0">
+          This page could not be found.
+        </h2>
+      </div>
+    </div>
+    <br>
+    <a href="{{ site.LanguagePrefix }}/">
+      Return to home page
+    </a>
+  </body>
+</html>

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="pt">
+  <body style='font-family:system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"; height:100vh; text-align:center; display:flex; flex-direction:column; align-items:center; justify-content:center'>
+    <div>
+      <style>
+        body {
+          color: #000;
+          background: #fff;
+          margin: 0;
+        }
+
+        .next-error-h1 {
+           border-right: 1px solid rgba(0, 0, 0, 0.3);
+        }
+
+        @media (prefers-color-scheme: dark) {
+          body {
+            color: #fff;
+            background: #000;
+          }
+
+          .next-error-h1 {
+            border-right: 1px solid rgba(255, 255, 255, 0.3);
+          }
+        }
+        a {
+          margin-top: 2rem;
+          color: #fff;
+        }
+        a:visited {
+          color: #fff;
+          text-decoration: none;
+        }
+      </style>
+      <h1 class="next-error-h1" style='display: inline-block; margin: 0 20px 0 0; padding-right: 23px; font-size: 24px; font-weight: 500; vertical-align: top; line-height: 49px; font-feature-settings: "rlig" 1,"calt" 1,"ss01" 1,"ss06" 1 !important;'>
+        404
+      </h1>
+      <div style="display: inline-block; text-align: left">
+        <h2 style="font-size: 14px; font-weight: 400; line-height: 49px; margin: 0">
+          Esta página não pode ser encontrada.
+        </h2>
+      </div>
+    </div>
+    <br>
+    <a href="{{ site.LanguagePrefix }}/">
+      Voltar para a página inicial
+    </a>
+  </body>
+</html>


### PR DESCRIPTION
[This was generated by Copilot]

This pull request adds custom 404 error pages in both English and Portuguese to improve user experience for missing pages. The new pages feature a clear message, a consistent design, and a link to return to the home page.

**Localization improvements:**

* Added a Portuguese 404 error page in `layouts/404.html` with localized messaging and a link to return to the home page.
* Added an English 404 error page in `layouts/404.en.html` with messaging in English and a link to return to the home page.

**Styling and accessibility:**

* Both pages include responsive design and support for dark mode, ensuring readability and accessibility across devices and user preferences. [[1]](diffhunk://#diff-42aff17c51e9204b20b909c28982dd41606701efc042881bae0c196f8177c9f6R1-R49) [[2]](diffhunk://#diff-554a0554013a4ec1a527cb686a863d346df6283b93deb7a38a98348d1aefb8e1R1-R49)